### PR TITLE
Feature | setUp and tearDown improvements

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -204,10 +204,6 @@ $job->setChunk(new Chunk(totalItems: 100, chunkSize: 10, startingPosition: 5));
 dispatch($job);
 ```
 
-## Setup Callback
-
-If you would like to execute some logic before the chunking starts, you can extend the `setUp` method on your chunkable job which will be run once.
-
 ## Using `ChunkRange` to iterate over all chunks
 
 If you need to iterate over every chunk, you can use the `ChunkRange` class. This will return a generator that you can iterate over to get every chunk.
@@ -278,6 +274,7 @@ The `setUp` and `tearDown` methods are called before and after the chunking proc
 
 use Sammyjo20\ChunkableJobs\Chunk;
 use Sammyjo20\ChunkableJobs\ChunkableJob;
+use Illuminate\Support\Facades\Log;
 
 class GetPageOfPokemon extends ChunkableJob implements ShouldQueue
 {
@@ -303,12 +300,12 @@ class GetPageOfPokemon extends ChunkableJob implements ShouldQueue
     
     protected function setUp(): void
     {
-        \Log::info('Starting the retrieval process...');
+        Log::info('Starting the retrieval process...');
     }
     
     protected function tearDown(): void
     {
-        \Log::info('Finished the retrieval process!');
+        Log::info('Finished the retrieval process!');
     }
 }
 ```

--- a/src/BulkChunkDispatcher.php
+++ b/src/BulkChunkDispatcher.php
@@ -34,6 +34,8 @@ class BulkChunkDispatcher
         foreach ($chunkRange as $chunk) {
             $chunk->disableNext();
 
+            ray($chunk, $chunk->isFirst(), $chunk->isLast());
+
             $dispatchJob = clone $job;
             $dispatchJob->setChunk($chunk);
 

--- a/src/BulkChunkDispatcher.php
+++ b/src/BulkChunkDispatcher.php
@@ -34,8 +34,7 @@ class BulkChunkDispatcher
         foreach ($chunkRange as $chunk) {
             $chunk->disableNext();
 
-            $dispatchJob = clone $job;
-            $dispatchJob->setChunk($chunk);
+            $dispatchJob = (clone $job)->setChunk($chunk);
 
             dispatch($dispatchJob);
         }

--- a/src/BulkChunkDispatcher.php
+++ b/src/BulkChunkDispatcher.php
@@ -34,8 +34,6 @@ class BulkChunkDispatcher
         foreach ($chunkRange as $chunk) {
             $chunk->disableNext();
 
-            ray($chunk, $chunk->isFirst(), $chunk->isLast());
-
             $dispatchJob = clone $job;
             $dispatchJob->setChunk($chunk);
 

--- a/src/Chunk.php
+++ b/src/Chunk.php
@@ -128,20 +128,11 @@ class Chunk
      */
     public function next(): Chunk
     {
-        if ($this->disableNext === true || $this->isLast()) {
+        if ($this->isLast() || $this->isNextDisabled()) {
             return $this;
         }
 
-        $next = clone $this;
-
-        $next->position++;
-        $next->remainingItems -= $next->size;
-        $next->remainingChunks--;
-        $next->offset += $next->size;
-        $next->limit = min($next->remainingItems, $next->size);
-        $next->size = $next->limit;
-
-        return $next;
+        return $this->move($this->position + 1);
     }
 
     /**
@@ -233,7 +224,7 @@ class Chunk
      */
     public function isLast(): bool
     {
-        return $this->remainingChunks === 0 || $this->disableNext === true;
+        return $this->remainingChunks === 0;
     }
 
     /**
@@ -276,5 +267,27 @@ class Chunk
         $this->disableNext = true;
 
         return $this;
+    }
+
+    /**
+     * Enable the next chunk functionality
+     *
+     * @return $this
+     */
+    public function enableNext(): Chunk
+    {
+        $this->disableNext = false;
+
+        return $this;
+    }
+
+    /**
+     * Check if the next is disabled.
+     *
+     * @return bool
+     */
+    public function isNextDisabled(): bool
+    {
+        return $this->disableNext === true;
     }
 }

--- a/src/Chunk.php
+++ b/src/Chunk.php
@@ -158,7 +158,7 @@ class Chunk
 
         // Now we'll create a new chunk to process it with.
 
-        $newChunk = new Chunk($this->totalItems, $this->originalSize);
+        $newChunk = clone $this;
 
         $newChunk->position = $position;
         $newChunk->remainingItems = $remaining;
@@ -166,13 +166,8 @@ class Chunk
         $newChunk->offset = ($position - 1) * $this->originalSize;
         $newChunk->limit = min($remaining, $this->originalSize);
         $newChunk->size = $newChunk->limit;
-        $newChunk->metadata = $this->metadata;
 
-        if ($mutable === false) {
-            return $newChunk;
-        }
-
-        return $this->replace($newChunk);
+        return $mutable === true ? $this->replace($newChunk) : $newChunk;
     }
 
     /**

--- a/src/ChunkRange.php
+++ b/src/ChunkRange.php
@@ -20,7 +20,7 @@ class ChunkRange
     {
         $chunk = new Chunk($totalItems, $chunkSize, 1, $metadata);
 
-        $generator = function () use ($chunk) {
+        $generator = static function () use ($chunk) {
             for ($i = 0; $i < $chunk->totalChunks; $i++) {
                 yield $chunk->move($i + 1);
             }

--- a/src/ChunkableJob.php
+++ b/src/ChunkableJob.php
@@ -47,14 +47,16 @@ abstract class ChunkableJob
     public function handle(): void
     {
         if (is_null($this->chunk)) {
-            $this->setUp();
-
             $this->setChunk($this->defineChunk());
         }
 
         $chunk = $this->chunk;
 
         if ($chunk instanceof Chunk && $chunk->isNotEmpty()) {
+            if ($chunk->isFirst()) {
+                $this->setUp();
+            }
+
             $this->handleChunk($chunk);
 
             $this->prependNextJob();

--- a/src/ChunkableJob.php
+++ b/src/ChunkableJob.php
@@ -57,16 +57,14 @@ abstract class ChunkableJob
         $chunk = $this->chunk;
 
         // If we have a chunk, and it isn't empty, we will start
-        // processing it. If it's the first chunk we will run
-        // "setUp".
+        // processing it.
 
-        if (! $chunk instanceof Chunk) {
+        if (! $chunk instanceof Chunk || $chunk->isEmpty()) {
             return;
         }
 
-        if ($chunk->isEmpty()) {
-            return;
-        }
+        // If it's the first chunk we will run "setUp". After
+        // that we will run the "handleChunk" method.
 
         if ($chunk->isFirst()) {
             $this->setUp();
@@ -178,18 +176,6 @@ abstract class ChunkableJob
     }
 
     /**
-     * Stop chunking
-     *
-     * @return $this
-     */
-    public function stopChunking(): static
-    {
-        $this->processNextChunk = false;
-
-        return $this;
-    }
-
-    /**
      * Set the next chunk to be processed.
      *
      * @param Chunk|null $nextChunk
@@ -198,6 +184,18 @@ abstract class ChunkableJob
     public function setNextChunk(?Chunk $nextChunk): ChunkableJob
     {
         $this->nextChunk = $nextChunk;
+
+        return $this;
+    }
+
+    /**
+     * Stop chunking
+     *
+     * @return $this
+     */
+    public function stopChunking(): static
+    {
+        $this->processNextChunk = false;
 
         return $this;
     }

--- a/tests/Feature/BulkChunkDispatcherTest.php
+++ b/tests/Feature/BulkChunkDispatcherTest.php
@@ -32,10 +32,16 @@ test('the dispatched jobs wont run the next chain', function () {
     expect($chunkTwo->offset)->toEqual(10);
     expect($chunkThree->offset)->toEqual(20);
 
-    // Every chunk should be considered last as the next is disabled.
+    // Every chunk should have next disabled
 
-    expect($chunkOne->isLast())->toBeTrue();
-    expect($chunkTwo->isLast())->toBeTrue();
+    expect($chunkOne->isNextDisabled())->toBeTrue();
+    expect($chunkTwo->isNextDisabled())->toBeTrue();
+    expect($chunkThree->isNextDisabled())->toBeTrue();
+
+    // But only the last chunk is the last
+
+    expect($chunkOne->isLast())->toBeFalse();
+    expect($chunkTwo->isLast())->toBeFalse();
     expect($chunkThree->isLast())->toBeTrue();
 });
 

--- a/tests/Feature/ChunkableJobTest.php
+++ b/tests/Feature/ChunkableJobTest.php
@@ -1,18 +1,19 @@
 <?php declare(strict_types=1);
 
 use Sammyjo20\ChunkableJobs\Chunk;
-use Sammyjo20\ChunkableJobs\Tests\Fixtures\SetUpAndTearDownJob;
+use Sammyjo20\ChunkableJobs\Tests\Fixtures\SetUpJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\FailedJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\ReleasedJob;
+use Sammyjo20\ChunkableJobs\Tests\Fixtures\TearDownJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\NextChunkJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\NullChunkJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\PaginatedJob;
-use Sammyjo20\ChunkableJobs\Tests\Fixtures\TearDownJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\ZeroItemsJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\EarlyFinishJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\UnknownSizeJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\ChunkIntervalJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\ExtraPropertiesJob;
+use Sammyjo20\ChunkableJobs\Tests\Fixtures\SetUpAndTearDownJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\ExtraUnsetPropertiesJob;
 
 test('when dispatching a job that has 30 items with a chunk size of 10, three jobs will be dispatched', function () {
@@ -99,19 +100,28 @@ test('the setUp and tearDown methods are only run once each when dispatching eve
 
     expect($setUpCount)->toEqual(1);
 
-    // This is run three times...
-
     $tearDownCount = cache()->get('tearDown');
 
     expect($tearDownCount)->toEqual(1);
 });
 
 test('the set up method is run even when you provide a chunk', function () {
+    $job = new SetUpJob();
+    $job->setChunk(new Chunk(30, 5));
 
+    dispatch($job);
+
+    $setUpCount = cache()->get('setUp');
+
+    expect($setUpCount)->toEqual(1);
 });
 
 test('the tear down method is run when a chunkable job is cancelled', function () {
+    TearDownJob::dispatch();
 
+    $tearDownCount = cache()->get('tearDown');
+
+    expect($tearDownCount)->toEqual(1);
 });
 
 test('if the job is released it wont dispatch the next chunk', function () {

--- a/tests/Feature/ChunkableJobTest.php
+++ b/tests/Feature/ChunkableJobTest.php
@@ -1,12 +1,13 @@
 <?php declare(strict_types=1);
 
 use Sammyjo20\ChunkableJobs\Chunk;
-use Sammyjo20\ChunkableJobs\Tests\Fixtures\SetUpJob;
+use Sammyjo20\ChunkableJobs\Tests\Fixtures\SetUpAndTearDownJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\FailedJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\ReleasedJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\NextChunkJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\NullChunkJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\PaginatedJob;
+use Sammyjo20\ChunkableJobs\Tests\Fixtures\TearDownJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\ZeroItemsJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\EarlyFinishJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\UnknownSizeJob;
@@ -63,8 +64,8 @@ test('when dispatching a job that returns zero items inside of the chunk it wont
     expect(cache()->get('processed'))->toBeFalse();
 });
 
-test('the setUp callback is executed the first time a chunked job is run', function () {
-    SetUpJob::dispatch();
+test('the setUp and tearDown callbacks are executed the first time a chunked job is run', function () {
+    SetUpAndTearDownJob::dispatch();
 
     $chunkOne = cache()->get('1');
     $chunkTwo = cache()->get('2');
@@ -74,9 +75,43 @@ test('the setUp callback is executed the first time a chunked job is run', funct
     expect($chunkTwo)->toBeInstanceOf(Chunk::class);
     expect($chunkThree)->toBeInstanceOf(Chunk::class);
 
-    $count = cache()->get('setUp');
+    $setUpCount = cache()->get('setUp');
 
-    expect($count)->toEqual(1);
+    expect($setUpCount)->toEqual(1);
+
+    $tearDownCount = cache()->get('tearDown');
+
+    expect($tearDownCount)->toEqual(1);
+});
+
+test('the setUp and tearDown methods are only run once each when dispatching every job', function () {
+    SetUpAndTearDownJob::dispatchAllChunks();
+
+    $chunkOne = cache()->get('1');
+    $chunkTwo = cache()->get('2');
+    $chunkThree = cache()->get('3');
+
+    expect($chunkOne)->toBeInstanceOf(Chunk::class);
+    expect($chunkTwo)->toBeInstanceOf(Chunk::class);
+    expect($chunkThree)->toBeInstanceOf(Chunk::class);
+
+    $setUpCount = cache()->get('setUp');
+
+    expect($setUpCount)->toEqual(1);
+
+    // This is run three times...
+
+    $tearDownCount = cache()->get('tearDown');
+
+    expect($tearDownCount)->toEqual(1);
+});
+
+test('the set up method is run even when you provide a chunk', function () {
+
+});
+
+test('the tear down method is run when a chunkable job is cancelled', function () {
+
 });
 
 test('if the job is released it wont dispatch the next chunk', function () {

--- a/tests/Fixtures/SetUpAndTearDownJob.php
+++ b/tests/Fixtures/SetUpAndTearDownJob.php
@@ -10,7 +10,7 @@ use Sammyjo20\ChunkableJobs\ChunkableJob;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 
-class SetUpJob extends ChunkableJob implements ShouldQueue
+class SetUpAndTearDownJob extends ChunkableJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
@@ -22,6 +22,11 @@ class SetUpJob extends ChunkableJob implements ShouldQueue
     protected function setUp(): void
     {
         cache()->increment('setUp');
+    }
+
+    protected function tearDown(): void
+    {
+        cache()->increment('tearDown');
     }
 
     protected function handleChunk(Chunk $chunk): void

--- a/tests/Fixtures/SetUpJob.php
+++ b/tests/Fixtures/SetUpJob.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Sammyjo20\ChunkableJobs\Tests\Fixtures;
+
+use Illuminate\Bus\Queueable;
+use Sammyjo20\ChunkableJobs\Chunk;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Sammyjo20\ChunkableJobs\ChunkableJob;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class SetUpJob extends ChunkableJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function defineChunk(): ?Chunk
+    {
+        return new Chunk(30, 10);
+    }
+
+    protected function setUp(): void
+    {
+        cache()->increment('setUp');
+    }
+
+    protected function handleChunk(Chunk $chunk): void
+    {
+        cache()->put($chunk->position, $chunk);
+    }
+}

--- a/tests/Fixtures/TearDownJob.php
+++ b/tests/Fixtures/TearDownJob.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Sammyjo20\ChunkableJobs\Tests\Fixtures;
+
+use Illuminate\Bus\Queueable;
+use Sammyjo20\ChunkableJobs\Chunk;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Sammyjo20\ChunkableJobs\ChunkableJob;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class TearDownJob extends ChunkableJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function defineChunk(): ?Chunk
+    {
+        return new Chunk(30, 10);
+    }
+
+    protected function tearDown(): void
+    {
+        cache()->increment('tearDown');
+    }
+
+    protected function handleChunk(Chunk $chunk): void
+    {
+        cache()->put($chunk->position, $chunk);
+
+        if ($chunk->position === 2) {
+            $this->stopChunking();
+        }
+    }
+}

--- a/tests/Unit/ChunkTest.php
+++ b/tests/Unit/ChunkTest.php
@@ -306,7 +306,7 @@ test('metadata can be passed in to the constructor', function () {
     expect($chunk->metadata)->toEqual(['name' => 'Sam']);
 });
 
-test('you can disable the next chunk functionality', function () {
+test('you can disable and enable the next chunk functionality', function () {
     $chunk = new Chunk(30, 10);
 
     $nextChunk = $chunk->next();
@@ -316,6 +316,15 @@ test('you can disable the next chunk functionality', function () {
 
     $nextChunk->disableNext();
 
-    expect($nextChunk->isLast())->toBeTrue();
+    expect($nextChunk->isLast())->toBeFalse();
     expect($nextChunk->next())->toBe($nextChunk);
+    expect($nextChunk->isNextDisabled())->toBeTrue();
+
+    $nextChunk->enableNext();
+
+    $lastChunk = $chunk->move(3);
+
+    expect($nextChunk->isLast())->toBeFalse();
+    expect($nextChunk->next())->toEqual($lastChunk);
+    expect($nextChunk->isNextDisabled())->toBeFalse();
 });


### PR DESCRIPTION
This PR improves the tests for the `setUp` and `tearDown` methods. It also changes the logic so if you dispatch all chunks, they now won't each consider themselves as the last chunk, but they won't progress to the next chunk.

Resolves #6 