### PR TITLE
Feature | Renamed `extraUnsetProperties` to `ignoredProperties`

### DIFF
--- a/src/ChunkableJob.php
+++ b/src/ChunkableJob.php
@@ -37,7 +37,7 @@ abstract class ChunkableJob
      *
      * @var array
      */
-    protected array $extraUnsetProperties = [];
+    protected array $ignoredProperties = [];
 
     /**
      * Process the job.
@@ -125,15 +125,19 @@ abstract class ChunkableJob
         // is the "job" instance on the class, but we also want to ignore chunk
         // and nextChunk.
 
-        $unsetProperties = array_merge([
+        $ignoredProperties = array_merge([
             'job', 'middleware', 'chunk', 'nextChunk',
-        ], $this->extraUnsetProperties);
+        ], $this->ignoredProperties);
 
         $clone = clone $this;
 
-        foreach ($unsetProperties as $property) {
+        foreach ($ignoredProperties as $property) {
             unset($clone->$property);
         }
+
+        // We'll also trigger a method that can be implemented to unset
+
+        $clone = $this->modifyClone($clone);
 
         // Next, we'll set the chunk of the clone to the next chunk.
 
@@ -210,6 +214,17 @@ abstract class ChunkableJob
     public static function dispatchAllChunks(...$arguments): void
     {
         BulkChunkDispatcher::dispatch(new static(...$arguments));
+    }
+
+    /**
+     * Modify the clone before it is sent.
+     *
+     * @param ChunkableJob $job
+     * @return $this
+     */
+    protected function modifyClone(ChunkableJob $job): static
+    {
+        return $job;
     }
 
     /**

--- a/tests/Feature/ChunkableJobTest.php
+++ b/tests/Feature/ChunkableJobTest.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Sammyjo20\ChunkableJobs\Chunk;
+use Sammyjo20\ChunkableJobs\Tests\Fixtures\InvisibleIgnoredPropertiesJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\SetUpJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\FailedJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\ReleasedJob;
@@ -14,7 +15,7 @@ use Sammyjo20\ChunkableJobs\Tests\Fixtures\UnknownSizeJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\ChunkIntervalJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\ExtraPropertiesJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\SetUpAndTearDownJob;
-use Sammyjo20\ChunkableJobs\Tests\Fixtures\ExtraUnsetPropertiesJob;
+use Sammyjo20\ChunkableJobs\Tests\Fixtures\IgnoredPropertiesJob;
 
 test('when dispatching a job that has 30 items with a chunk size of 10, three jobs will be dispatched', function () {
     PaginatedJob::dispatch();
@@ -211,8 +212,8 @@ test('extra properties are copied over to every job', function () {
     expect($chunkThree)->toEqual('Sam');
 });
 
-test('you can specify extra properties to be unset', function () {
-    ExtraUnsetPropertiesJob::dispatch();
+test('you can specify extra properties to be ignored on clone', function () {
+    IgnoredPropertiesJob::dispatch();
 
     $chunkOne = cache()->get('1');
     $chunkTwo = cache()->get('2');
@@ -221,4 +222,16 @@ test('you can specify extra properties to be unset', function () {
     expect($chunkOne)->toEqual('Sam');
     expect($chunkTwo)->toBeNull();
     expect($chunkThree)->toBeNull();
+});
+
+test('you can overwrite the modifyClone method to unset your own properties', function () {
+    InvisibleIgnoredPropertiesJob::dispatch();
+
+    $chunkOne = cache()->get('1');
+    $chunkTwo = cache()->get('2');
+    $chunkThree = cache()->get('3');
+
+    expect($chunkOne)->toEqual('SamFlip');
+    expect($chunkTwo)->toEqual('');
+    expect($chunkThree)->toEqual('');
 });

--- a/tests/Feature/ChunkableJobTest.php
+++ b/tests/Feature/ChunkableJobTest.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 
 use Sammyjo20\ChunkableJobs\Chunk;
-use Sammyjo20\ChunkableJobs\Tests\Fixtures\InvisibleIgnoredPropertiesJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\SetUpJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\FailedJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\ReleasedJob;
@@ -16,6 +15,7 @@ use Sammyjo20\ChunkableJobs\Tests\Fixtures\ChunkIntervalJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\ExtraPropertiesJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\SetUpAndTearDownJob;
 use Sammyjo20\ChunkableJobs\Tests\Fixtures\IgnoredPropertiesJob;
+use Sammyjo20\ChunkableJobs\Tests\Fixtures\InvisibleIgnoredPropertiesJob;
 
 test('when dispatching a job that has 30 items with a chunk size of 10, three jobs will be dispatched', function () {
     PaginatedJob::dispatch();

--- a/tests/Fixtures/IgnoredPropertiesJob.php
+++ b/tests/Fixtures/IgnoredPropertiesJob.php
@@ -10,11 +10,11 @@ use Sammyjo20\ChunkableJobs\ChunkableJob;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 
-class ExtraUnsetPropertiesJob extends ChunkableJob implements ShouldQueue
+class IgnoredPropertiesJob extends ChunkableJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    protected array $extraUnsetProperties = ['name'];
+    protected array $ignoredProperties = ['name'];
 
     /**
      * @var string

--- a/tests/Fixtures/InvisibleIgnoredPropertiesJob.php
+++ b/tests/Fixtures/InvisibleIgnoredPropertiesJob.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Sammyjo20\ChunkableJobs\Tests\Fixtures;
+
+use Illuminate\Bus\Queueable;
+use Sammyjo20\ChunkableJobs\Chunk;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Sammyjo20\ChunkableJobs\ChunkableJob;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class InvisibleIgnoredPropertiesJob extends ChunkableJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected array $ignoredProperties = ['name'];
+
+    /**
+     * @var string|null
+     */
+    protected ?string $name = null;
+
+    /**
+     * @var string|null
+     */
+    private ?string $codeword = null;
+
+    public function __construct()
+    {
+        $this->name = 'Sam';
+        $this->codeword = 'Flip';
+    }
+
+    public function defineChunk(): ?Chunk
+    {
+        return new Chunk(30, 10);
+    }
+
+    protected function handleChunk(Chunk $chunk): void
+    {
+        cache()->put($chunk->position, $this->name . $this->codeword);
+    }
+
+    protected function modifyClone(ChunkableJob $job): static
+    {
+        unset($job->codeword);
+
+        return $job;
+    }
+}


### PR DESCRIPTION
This PR just improves the documentation about property cloning and a couple of ways to disable cloning properties you don't want to be shared.