### PR TITLE
Support for php 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1]
+        php: [8.0, 8.1]
         laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.1"
+        "php": "^8.0|^8.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.5",


### PR DESCRIPTION
This PR adds support for php 8.0 .
No further changes other than the `composer.json` php version (probably `^7.4` could be supported out of the box too).